### PR TITLE
DNS service handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,10 @@ microk8s_disable_snap_autoupdate: false
 
 microk8s_registry_size: 20Gi
 
+microk8s_dns_servers:
+  - 8.8.8.8
+  - 8.8.4.4
+
 ## microk8s_users to make members of microk8s group
 microk8s_users: []
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -116,6 +116,7 @@
     - microk8s_plugins is defined
     - microk8s_plugin.value
     - microk8s_plugin.key != "registry"
+    - microk8s_plugin.key != "dns"
   register: microk8s_cmd_result
   changed_when:
     - "'Addon {{ microk8s_plugin.key }} is already enabled'
@@ -178,6 +179,22 @@
     - microk8s.plugins
     - microk8s.plugins.disable
     - microk8s.plugins.disable.registry
+
+- name: Enable DNS
+  ansible.builtin.command:
+    cmd: 'microk8s.enable dns:{{ microk8s_dns_servers | join(",") }}'
+  register: microk8s_cmd_result
+  changed_when:
+    - "'Addon dns is already enabled' not in microk8s_cmd_result.stdout"
+  when:
+    - microk8s_plugins is defined
+    - microk8s_plugins.dns is defined
+    - (microk8s_plugins.dns | bool)
+  tags:
+    - microk8s
+    - microk8s.plugins
+    - microk8s.plugins.enable
+    - microk8s.plugins.enable.dns
 
 - name: Disable snap autoupdate
   ansible.builtin.blockinfile:


### PR DESCRIPTION
Enabling the dns service in microk8s allows the user to define the dns forwarders to use instead of [8.8.8.8, 8.8.4.4]. I copied the enable registry task to allow to define a different set of upstream dns servers in microk8s.